### PR TITLE
Ensure .tsx files are supported.

### DIFF
--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -112,4 +112,21 @@ describe("builder/builder module has a", () => {
             assert.equal(result, "./directory2/script");
         });
     });
+    describe("getBasename function that", () => {
+        it("should correctly strip .ts from the filename", () => {
+            const fileName = "./random/path/file.ts";
+            const result = Builder.getBasename(fileName);
+            assert.equal(result, "file");
+        });
+        it("should correctly strip .tsx from the filename", () => {
+            const fileName = "./random/path/file.tsx";
+            const result = Builder.getBasename(fileName);
+            assert.equal(result, "file");
+        });
+        it("should not strip extensions from non-typescript filenames", () => {
+            const fileName = "./random/path/file.cs";
+            const result = Builder.getBasename(fileName);
+            assert.equal(result, "file.cs");
+        });
+    });
 });

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -53,9 +53,18 @@ export function buildImportPath(directory: Directory, target: Location): string 
     if (directoryPath !== ".") {
         directoryPath = `.${path.sep}${directoryPath}`;
     }
-    // Strip off the .ts from the file name.
-    const fileName = path.basename(relativePath, ".ts");
+    // Strip off the .ts or .tsx from the file name.
+    const fileName = getBasename(relativePath);
     // Build the final path string. Use posix-style seperators.
     const location = `${directoryPath}${path.sep}${fileName}`;
     return convertPathSeparator(location);
+}
+
+/** Strips the .ts or .tsx file extension from a path and returns the base filename. */
+export function getBasename(relativePath: string) {
+     const strippedTsPath = path.basename(relativePath, ".ts");
+     const strippedTsxPath = path.basename(relativePath, ".tsx");
+
+     // Return whichever path is shorter. If they're the same length then nothing was stripped.
+     return strippedTsPath.length < strippedTsxPath.length ? strippedTsPath : strippedTsxPath;
 }

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -13,8 +13,11 @@ describe("utilities module has a", () => {
         it("should match a typescript definition file", () => {
             assert.notEqual("definitions.d.ts".search(Utilities.isTypeScriptFile), -1);
         });
+        it("should match a typescript jsx (.tsx) file", () => {
+            assert.notEqual("other.tsx".search(Utilities.isTypeScriptFile), -1);
+        });
         it("should not match a non-typescript file", () => {
-            assert.equal("other.tsx".search(Utilities.isTypeScriptFile), -1);
+            assert.equal("other.cs".search(Utilities.isTypeScriptFile), -1);
         });
     });
     describe("nonAlphaNumeric regular expression that", () => {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -21,6 +21,6 @@ export function convertPathSeparator(path: string): string {
     return path.replace(/\\+/g, "/");
 }
 
-export const isTypeScriptFile = /\.ts$/m;
+export const isTypeScriptFile = /\.tsx?$/m;
 export const nonAlphaNumeric = /\W+/g;
 export const indentation = "  ";


### PR DESCRIPTION
This pull request should fix #21. I've tested it on my machine and it was working as expected, exporting from both `.ts` and `.tsx` files. I had to make a change to `src/fileTree.test.ts` to fix a TypeScript type error, and a change to `src/options.test.ts` to fix a tslint error, though. I've left both of those changes out since they were present already in the Barrelsby master branch, I assume they're just configuration errors on my end. 