### PR TITLE
Remove outdated link to Angular Glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ import * as Controls from "./src/controls/index";
 
 ### More Reading
 
-* [Angular Glossary](https://angular.io/docs/ts/latest/glossary.html#!#B)
 * [TattooCoder Blog](http://tattoocoder.com/angular2-barrels/)
 
 ### Barrelsby Articles


### PR DESCRIPTION
Barrels aren't mentioned anymore on the Angular Glossary - because of that the link to the Angular Glossary should be removed to prevent confusion.
Maybe we could add a link to an old version of the docs like https://v4.angular.io/guide/glossary#B?