### PR TITLE
bugfix - fix integration tests

### DIFF
--- a/test/src.js
+++ b/test/src.js
@@ -20,7 +20,10 @@ Promise.all(fs_1.readdirSync(location)
     .filter(path => fs_1.lstatSync(path).isDirectory())
     .map(directory => {
     const args = yargs_1.default.parse(["--config", path_1.join(directory, "barrelsby.json")]);
-    args.directory = path_1.join(directory, args.directory);
+    // args.directory is expected to be a string array, so combine the first directory in the test config
+    // with the current directory, as pass that back as an array
+    const firstDir = args.directory[0];
+    args.directory = [path_1.join(directory, firstDir)];
     return fs_extra_1.copy(path_1.join(directory, "input"), path_1.join(directory, "output")).then(() => {
         bin_1.default(args);
         console.log(`Running integration test in directory ${directory}`);

--- a/test/src.ts
+++ b/test/src.ts
@@ -15,64 +15,67 @@ const console = require("better-console");
 getArgs();
 const location = join(__dirname, "./");
 Promise.all(
-  readdirSync(location)
-    .map(name => join(location, name))
-    .filter(path => lstatSync(path).isDirectory())
-    .map(directory => {
-      const args = Yargs.parse(["--config", join(directory, "barrelsby.json")]);
-      args.directory = join(directory, args.directory as string);
-      return copy(join(directory, "input"), join(directory, "output")).then(
-        () => {
-          Barrelsby(args as any);
-          console.log(`Running integration test in directory ${directory}`);
-          const outputDirectory = join(directory, "output");
-          const expectedDirectory = join(directory, "expected");
-          console.log("Output directory:", outputDirectory);
-          console.log("Expected directory:", expectedDirectory);
-          const comparison = dirCompare.compareSync(
-            outputDirectory,
-            expectedDirectory,
-            {
-              compareContent: true,
-              compareFileAsync:
-                dirCompare.fileCompareHandlers.lineBasedFileCompare
-                  .compareAsync,
-              compareFileSync:
-                dirCompare.fileCompareHandlers.lineBasedFileCompare.compareSync,
-              ignoreLineEnding: true
-            }
-          );
-          if (comparison.differences && comparison.diffSet) {
-            comparison.diffSet
-              .filter(diff => diff.state !== "equal")
-              .map(diff => {
-                const state = ({
-                  distinct: "<>",
-                  equal: "==",
-                  left: "->",
-                  right: "<-"
-                } as any)[diff.state];
-                const name1 = diff.name1 ? diff.name1 : "";
-                const name2 = diff.name2 ? diff.name2 : "";
-                console.error(
-                  `${name1} ${diff.type1} ${state} ${name2} ${diff.type2}`
-                );
-              });
-          }
-          if (comparison.differences && comparison.diffSet) {
-            console.error(
-              `Error: ${comparison.differences} differences found!`
-            );
-          } else {
-            console.info(`No differences found in ${comparison.equalFiles}`);
-          }
-          console.log();
-          return comparison.differences;
-        }
-      );
-    })
+	readdirSync(location)
+		.map(name => join(location, name))
+		.filter(path => lstatSync(path).isDirectory())
+		.map(directory => {
+			const args = Yargs.parse(["--config", join(directory, "barrelsby.json")]);
+			// args.directory is expected to be a string array, so combine the first directory in the test config
+			// with the current directory, as pass that back as an array
+			const firstDir = (args.directory as string[])[0];
+			args.directory = [join(directory, firstDir)];
+			return copy(join(directory, "input"), join(directory, "output")).then(
+				() => {
+					Barrelsby(args as any);
+					console.log(`Running integration test in directory ${directory}`);
+					const outputDirectory = join(directory, "output");
+					const expectedDirectory = join(directory, "expected");
+					console.log("Output directory:", outputDirectory);
+					console.log("Expected directory:", expectedDirectory);
+					const comparison = dirCompare.compareSync(
+						outputDirectory,
+						expectedDirectory,
+						{
+							compareContent: true,
+							compareFileAsync:
+								dirCompare.fileCompareHandlers.lineBasedFileCompare
+									.compareAsync,
+							compareFileSync:
+								dirCompare.fileCompareHandlers.lineBasedFileCompare.compareSync,
+							ignoreLineEnding: true
+						}
+					);
+					if (comparison.differences && comparison.diffSet) {
+						comparison.diffSet
+							.filter(diff => diff.state !== "equal")
+							.map(diff => {
+								const state = ({
+									distinct: "<>",
+									equal: "==",
+									left: "->",
+									right: "<-"
+								} as any)[diff.state];
+								const name1 = diff.name1 ? diff.name1 : "";
+								const name2 = diff.name2 ? diff.name2 : "";
+								console.error(
+									`${name1} ${diff.type1} ${state} ${name2} ${diff.type2}`
+								);
+							});
+					}
+					if (comparison.differences && comparison.diffSet) {
+						console.error(
+							`Error: ${comparison.differences} differences found!`
+						);
+					} else {
+						console.info(`No differences found in ${comparison.equalFiles}`);
+					}
+					console.log();
+					return comparison.differences;
+				}
+			);
+		})
 ).then(differences =>
-  process.exit(
-    differences.filter(differenceCount => differenceCount > 0).length
-  )
+	process.exit(
+		differences.filter(differenceCount => differenceCount > 0).length
+	)
 );


### PR DESCRIPTION
@aarr0n mentioned in #141 that the integration tests were failing.
This fixes the test so that it expects a string[] from YArgs, and
passes as string[] to Barrelsby