### PR TITLE
:sparkles: Make barrel header optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export * from "./barrel";
 export { default as barrel } from "./barrel";
 ```
 
-### `-H` or `--help`
+### `-h` or `--help`
 
 Displays help information on the command line arguments that barrelsby accepts.
 
@@ -202,6 +202,10 @@ Use 'single quotes' in the generated barrel files instead of the default "double
 ### `-S` or `--noSemicolon`
 
 Omit semicolons from the end of lines in the generated barrel files.
+
+### `-H` or `--noHeader`
+
+Omit adding a header comment to the top of the barrel file.
 
 ### `-v` or `--version`
 

--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -31,6 +31,7 @@ describe('builder/builder module has a', () => {
     let builderSpy: Sinon.SinonSpy<
       [
         {
+          addHeader: boolean;
           directory: Directory;
           barrelType: StructureOption;
           quoteCharacter: QuoteCharacter;
@@ -52,6 +53,7 @@ describe('builder/builder module has a', () => {
       loggerSpy = spySandbox.spy(logger, 'debug');
       builderSpy = spySandbox.spy(BuildBarrelModule, 'buildBarrel');
       build({
+        addHeader: true,
         destinations: directory.directories,
         quoteCharacter: '"',
         semicolonCharacter: ';',
@@ -139,6 +141,7 @@ describe('builder/builder module has a', () => {
     const logger = new Signale();
     const runBuilder = () => {
       build({
+        addHeader: true,
         destinations: directory.directories,
         quoteCharacter: '"',
         semicolonCharacter: ';',

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -10,6 +10,7 @@ import { Directory } from './interfaces/directory.interface';
 import { FileTreeLocation } from './interfaces/location.interface';
 
 export const build = (params: {
+  addHeader: boolean;
   destinations: Directory[];
   quoteCharacter: QuoteCharacter;
   semicolonCharacter: SemicolonCharacter;
@@ -26,6 +27,7 @@ export const build = (params: {
     // Build the barrels.
     params?.destinations?.forEach((destination: Directory) =>
       buildBarrel({
+        addHeader: params.addHeader,
         directory: destination,
         barrelType: params.structure ?? StructureOption.FLAT,
         quoteCharacter: params.quoteCharacter,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -76,6 +76,7 @@ describe('main module', () => {
     expect(getDestinationsSpy.calledOnceWithExactly(builtTree, args.location, barrelName, signale)).toBeTruthy();
     expect(purgeSpy.calledOnceWithExactly(builtTree, args.delete, barrelName, signale)).toBeTruthy();
     expect(buildBarrelsSpy).toHaveBeenCalledWith({
+      addHeader: true,
       destinations,
       quoteCharacter,
       semicolonCharacter,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,6 +21,7 @@ describe('main module', () => {
   });
   it('should co-ordinate the main stages of the application', () => {
     const args: any = {
+      noHeader: false,
       baseUrl: './',
       delete: true,
       directory: ['testRootPath'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,8 @@ export function Barrelsby(args: Arguments) {
     // Create the barrels.
     const quoteCharacter = getQuoteCharacter(args.singleQuotes as boolean);
     const semicolonCharacter = getSemicolonCharacter(args.noSemicolon as boolean);
-    const addHeader = args.noHeader !== false;
+    // Add header to each barrel if the `noHeader` option is not true
+    const addHeader = args.noHeader === false;
 
     await build({
       addHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,10 @@ export function Barrelsby(args: Arguments) {
     // Create the barrels.
     const quoteCharacter = getQuoteCharacter(args.singleQuotes as boolean);
     const semicolonCharacter = getSemicolonCharacter(args.noSemicolon as boolean);
+    const addHeader = args.noHeader !== false;
+
     await build({
+      addHeader,
       destinations,
       quoteCharacter,
       semicolonCharacter,

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -16,6 +16,7 @@ export interface Arguments {
   delete?: boolean;
   exclude?: string[];
   exportDefault?: boolean;
+  noHeader?: boolean;
   help?: boolean;
   include?: string[];
   local?: boolean;
@@ -65,6 +66,12 @@ export function getOptionsConfig(configParser: any): {
       type: 'array',
       alias: 'exportDefault',
       description: 'Also export the default export of the file. Currently works only with the `flat` mode.',
+    },
+    H: {
+      type: 'boolean',
+      alias: 'noHeader',
+      description: 'Do not add a header comment to the top of the barrel file.',
+      default: false,
     },
     i: {
       type: 'array',

--- a/src/tasks/BuildBarrel.ts
+++ b/src/tasks/BuildBarrel.ts
@@ -13,6 +13,7 @@ import { buildFlatBarrel } from '../builders/flat';
 import { StructureOption } from '../options/options';
 
 export const buildBarrel = ({
+  addHeader,
   directory,
   barrelType,
   quoteCharacter,
@@ -25,6 +26,7 @@ export const buildBarrel = ({
   include,
   exclude,
 }: {
+  addHeader: boolean;
   directory: Directory;
   barrelType: StructureOption;
   quoteCharacter: QuoteCharacter;
@@ -68,7 +70,7 @@ export const buildBarrel = ({
     return;
   }
   // Add the header
-  const contentWithHeader = addHeaderPrefix(content);
+  const contentWithHeader = addHeader ? addHeaderPrefix(content) : content;
   fs.writeFileSync(destination, contentWithHeader);
   // Update the file tree model with the new barrel.
   if (!directory.files.some(file => file.name === barrelName)) {


### PR DESCRIPTION
First of all, thanks for the great tool!

Motivation for this PR: in our project there is no real need to know where a barrel file came from. We have existing barrel files without such comments and the fact that some files do have special comments feels odd and will raise eyebrows. Also, in the future we might use different tools to create these.

The PR adds a new CLI flag `noHeader` that can be used to suppress the comments on top of `index.ts` files.

