### PR TITLE
[Fix] exportDefault - dot/dash filename support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,31 +1,51 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=733558
 	// for the documentation about the tasks.json format
-	"version": "0.1.0",
+	"version": "2.0.0",
 	"command": "npm",
-	"isShellCommand": true,
-	"showOutput": "always",
-	"suppressTaskName": true,
 	"echoCommand": true,
 	"tasks": [
 		{
-			"taskName": "install",
-			"args": ["install"]
+			"label": "install",
+			"type": "shell",
+			"args": [
+				"install"
+			],
+			"problemMatcher": []
 		},
 		{
-			"taskName": "update",
-			"args": ["update"]
+			"label": "update",
+			"type": "shell",
+			"args": [
+				"update"
+			],
+			"problemMatcher": []
 		},
 		{
-			"taskName": "test",
-			"args": ["run", "test"],
-			"problemMatcher": "$tsc"
+			"label": "test",
+			"type": "shell",
+			"args": [
+				"run",
+				"test"
+			],
+			"problemMatcher": "$tsc",
+			"group": {
+				"_id": "test",
+				"isDefault": false
+			}
 		},
 		{
-			"taskName": "build",
-			"args": ["run", "build"],
-			"isBuildCommand": true,
-			"problemMatcher": "$tsc"
+			"label": "build",
+			"type": "shell",
+			"args": [
+				"run",
+				"build"
+			],
+			"problemMatcher": "$tsc",
+			"group": {
+				"_id": "build",
+				"isDefault": false
+			}
 		}
 	]
 }

--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -1,0 +1,31 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "0.1.0",
+	"command": "npm",
+	"isShellCommand": true,
+	"showOutput": "always",
+	"suppressTaskName": true,
+	"echoCommand": true,
+	"tasks": [
+		{
+			"taskName": "install",
+			"args": ["install"]
+		},
+		{
+			"taskName": "update",
+			"args": ["update"]
+		},
+		{
+			"taskName": "test",
+			"args": ["run", "test"],
+			"problemMatcher": "$tsc"
+		},
+		{
+			"taskName": "build",
+			"args": ["run", "build"],
+			"isBuildCommand": true,
+			"problemMatcher": "$tsc"
+		}
+	]
+}

--- a/src/builders/flat.ts
+++ b/src/builders/flat.ts
@@ -6,6 +6,11 @@ import { QuoteCharacter } from '../options/quoteCharacter';
 import { Directory } from '../interfaces/directory.interface';
 import { FileTreeLocation } from '../interfaces/location.interface';
 
+
+function toCamelCase(str: string): string {
+  return str.replace(/[-_.]([a-z])/g, (_, group) => group.toUpperCase());
+}
+
 export function buildFlatBarrel(
   directory: Directory,
   modules: FileTreeLocation[],
@@ -20,7 +25,7 @@ export function buildFlatBarrel(
     logger.debug(`Including path ${importPath}`);
     if (exportDefault) {
       const filename = getBasename(current.path);
-      previous += `export { default as ${filename} } from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}
+      previous += `export { default as ${toCamelCase(filename)} } from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}
 `;
     }
     return (previous += `export * from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}

--- a/src/builders/flat.ts
+++ b/src/builders/flat.ts
@@ -6,7 +6,6 @@ import { QuoteCharacter } from '../options/quoteCharacter';
 import { Directory } from '../interfaces/directory.interface';
 import { FileTreeLocation } from '../interfaces/location.interface';
 
-
 function toCamelCase(str: string): string {
   return str.replace(/[-_.]([a-z])/g, (_, group) => group.toUpperCase());
 }
@@ -25,7 +24,9 @@ export function buildFlatBarrel(
     logger.debug(`Including path ${importPath}`);
     if (exportDefault) {
       const filename = getBasename(current.path);
-      previous += `export { default as ${toCamelCase(filename)} } from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}
+      previous += `export { default as ${toCamelCase(
+        filename
+      )} } from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}
 `;
     }
     return (previous += `export * from ${quoteCharacter}${importPath}${quoteCharacter}${semicolonCharacter}


### PR DESCRIPTION
with  `-E` flag and flat mode: 

current:
```ts
//  index.example is not valid name
export { default as index.example } from './something/index.example'

```

expect behaviour:
```ts
// if have dot filename
export { default as indexExample } from './something/index.example'
// if have dash filename
export { default as indexExample } from './something/index-example'
``` 