### PR TITLE
feat(api): Add programmatic API capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ Display the barrelsby version number.
 
 Display additional debug information.
 
+## Programmatic usage
+
+Yes! You can use barrelsby programmatically.
+
+```typescript
+import { Barrelsby, type Arguments } from "barrelsby";
+
+const args: Arguments = {
+    config: "path/to/barrelsby.json",
+    structure: "flat"
+}
+
+await Barrelsby(args);
+```
+
 ## Requirements
 
 Requires node v6.0.0 or greater for ES6 syntax.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "barrelsby",
   "version": "2.7.0",
   "description": "Automatic TypeScript barrels for your entire code base",
-  "main": "index.js",
+  "main": "bin/index.js",
+  "types" : "bin/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf bin/ && rimraf test/**/output/**",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,7 +19,7 @@ describe('main module', () => {
   afterEach(() => {
     spySandbox.restore();
   });
-  it('should co-ordinate the main stages of the application', () => {
+  it('should co-ordinate the main stages of the application', async () => {
     const args: any = {
       noHeader: false,
       baseUrl: './',
@@ -65,7 +65,7 @@ describe('main module', () => {
     const baseUrl = 'https://base-url.com/src/directory';
     const getCombinedBaseUrlSpy = spySandbox.stub(BaseUrl, 'getCombinedBaseUrl').returns(baseUrl);
 
-    Barrelsby(args);
+    await Barrelsby(args);
 
     expect(getQuoteCharacterSpy.calledOnceWithExactly(true)).toBeTruthy();
     expect(getSemicolonCharacterSpy.calledOnceWithExactly(true)).toBeTruthy();

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,11 @@ import { resolveRootPath } from './options/rootPath';
 import { purge } from './purge';
 import { Directory } from './interfaces/directory.interface';
 
+export type { Arguments };
+
 // TODO: Document how users can call this from their own code without using the CLI.
 // TODO: We might need to do some parameter validation for that.
-export function Barrelsby(args: Arguments) {
+export async function Barrelsby(args: Arguments): Promise<void> {
   // Get the launch options/arguments.
   const logger = getLogger({ isVerbose: args.verbose ?? false });
   const barrelName = getBarrelName(args.name ?? '', logger);
@@ -35,7 +37,7 @@ export function Barrelsby(args: Arguments) {
 
   logger.debug('resolved directories list', resolvedDirectories);
 
-  resolvedDirectories.forEach(async ({ rootPath, baseUrl }) => {
+  await Promise.all(resolvedDirectories.map(async ({ rootPath, baseUrl }) => {
     // Build the directory tree.
     const rootTree = buildTree(rootPath, barrelName, logger);
     logger.debug(`root tree for path: ${rootPath}`, rootTree);
@@ -68,5 +70,5 @@ export function Barrelsby(args: Arguments) {
       include: ([] as string[]).concat(args.include || []),
       exclude: ([] as string[]).concat(args.exclude || [], ['node_modules']),
     });
-  });
+  }));
 }


### PR DESCRIPTION
Makes the Barrelsby function actually async, so we can await barrelsby.

We also export the Arguments type via the index.ts for typing purposes.