### PR TITLE
fix: Fix incorrect gobal export alias in buildFlatBarrel

### DIFF
--- a/src/builders/flat.test.ts
+++ b/src/builders/flat.test.ts
@@ -3,6 +3,7 @@ import Sinon from 'sinon';
 import * as TestUtilities from '../testUtilities';
 import * as Flat from './flat';
 import { Signale } from 'signale';
+import { Directory } from '../interfaces/directory.interface';
 
 describe('builder/flat module has a', () => {
   describe('buildFlatBarrel function that', () => {
@@ -196,6 +197,39 @@ export * from "./directory3/program";
 `
         );
       });
+
+      it('should produce the correct output when a part of the filename starts with a number', () => {
+        const directory: Directory = {
+          directories: [],
+          files: [
+            {
+              name: 'file-with-number-1.ts',
+              path: 'directory1/file-with-number-1.ts',
+            },
+          ],
+          name: 'directory1',
+          path: './directory1',
+        };
+
+        const output = Flat.buildFlatBarrel(
+          directory,
+          TestUtilities.mockModules(directory),
+          '"',
+          ';',
+          signale,
+          undefined,
+          true,
+          false
+        );
+
+        TestUtilities.assertMultiLine(
+          output,
+          `export { default as fileWithNumber1 } from "./file-with-number-1";
+export * from "./file-with-number-1";
+`
+        );
+      });
+
       it('should produce output compatible with the recommended tslint ruleset', () => {
         TestUtilities.tslint(output, '"');
       });

--- a/src/builders/flat.ts
+++ b/src/builders/flat.ts
@@ -8,7 +8,7 @@ import { FileTreeLocation } from '../interfaces/location.interface';
 
 function dotOrDashStrToCamelCase(str: string): string {
   // massage any `example.file.name` to `exampleFileName`
-  return str.replace(/[-_.]([a-z])/g, (_, group) => group.toUpperCase());
+  return str.replace(/[-_.]([a-z0-9])/g, (_, group) => group.toUpperCase());
 }
 
 function arrayToCamelCase(arr: string[]) {


### PR DESCRIPTION
This fixes a bug where an invalid export alias was generated when filenames had segments that started with a number preceded by a dash or ".".

Examples using dashes and dots:
```typescript
export { default as testFile-1 } from "./directory1/test-file-1";
```
and
```typescript
export { default as testFile.1 } from "./directory1/test.file.1";
```

While underscores are allowed in aliases, dashes and dots are not.

Fix is to extend the regex to also include numbers.